### PR TITLE
Fix caching, path, and add workflow

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,29 @@
+name: Test Action
+
+on: [push, pull_request]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  first-run:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Run the action
+      uses: ./
+      with:
+        packages: latex-bin
+    - run: pdflatex test.tex
+
+  run-with-cache:
+    needs: first-run
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Run the action
+      uses: ./
+    - run: pdflatex test.tex

--- a/action.yml
+++ b/action.yml
@@ -35,7 +35,7 @@ runs:
       uses: actions/cache/restore@v3
       with:
         path: ~/texlive
-        key: texlive-${{ inputs.cache_version }}-${{ hashFiles(inputs.package_file, '/tmp/packages.txt') }}-${{ steps.get-date.outputs.date }}
+        key: texlive-${{ inputs.cache_version }}-${{ hashFiles(inputs.package_file) }}-${{ hashFiles('/tmp/packages.txt') }}-${{ steps.get-date.outputs.date }}
     - run: ${{ github.action_path }}/texlive.sh
       if: steps.load-cache.outputs.cache-hit != 'true'
       id: install

--- a/action.yml
+++ b/action.yml
@@ -30,12 +30,13 @@ runs:
       run: |
         echo "date=$(date -I)" >> $GITHUB_OUTPUT
         echo "${{ inputs.packages }}" > /tmp/packages.txt
+        cat /tmp/packages.txt
     - name: Load cache
       id: load-cache
       uses: actions/cache/restore@v3
       with:
         path: ~/texlive
-        key: texlive-${{ inputs.cache_version }}-${{ hashFiles(inputs.package_file) }}-${{ hashFiles('/tmp/packages.txt') }}-${{ steps.get-date.outputs.date }}
+        key: texlive-${{ inputs.cache_version }}-${{ hashFiles('/tmp/packages.txt') }}-${{ steps.get-date.outputs.date }}
     - run: ${{ github.action_path }}/texlive.sh
       if: steps.load-cache.outputs.cache-hit != 'true'
       id: install

--- a/action.yml
+++ b/action.yml
@@ -34,8 +34,7 @@ runs:
       uses: actions/cache/restore@v3
       with:
         path: ~/texlive
-        key: texlive-${{ inputs.cache_version }}-${{ hashFiles(inputs.package_file) }}-${{ steps.get-date.outputs.date }}
-        restore-keys: texlive-${{ inputs.cache_version }}-${{ hashFiles(inputs.package_file) }}-
+        key: texlive-${{ inputs.cache_version }}-${{ hashFiles(inputs.package_file) }}-${{ hashFiles(inputs.packages) }}-${{ steps.get-date.outputs.date }}
     - run: ${{ github.action_path }}/texlive.sh
       if: steps.load-cache.outputs.cache-hit != 'true'
       id: install
@@ -56,3 +55,6 @@ runs:
       run: |
         if ${{ steps.install.outcome == 'success' }} ; then echo "key=${{ steps.load-cache.outputs.cache-primary-key }}" ; else echo "key=${{ steps.load-cache.outputs.cache-matched-key }}" ; fi >> $GITHUB_OUTPUT
       id: key
+    - name: Set path
+      shell: sh
+      run: echo "$HOME/texlive/bin/x86_64-linux" >> $GITHUB_PATH

--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,7 @@ runs:
       with:
         path: ~/texlive
         key: texlive-${{ inputs.cache_version }}-${{ hashFiles(inputs.package_file) }}-${{ steps.key-parts.outputs.packages-hash }}-${{ steps.key-parts.outputs.date }}
+        restore-keys: texlive-${{ inputs.cache_version }}-${{ hashFiles(inputs.package_file) }}-${{ steps.key-parts.outputs.packages-hash }}-
     - run: ${{ github.action_path }}/texlive.sh
       if: steps.load-cache.outputs.cache-hit != 'true'
       id: install

--- a/action.yml
+++ b/action.yml
@@ -25,18 +25,17 @@ runs:
   using: "composite"
   steps:
     - name: Prepare cache key
-      shell: sh
-      id: get-date
+      id: key-parts
       run: |
         echo "date=$(date -I)" >> $GITHUB_OUTPUT
-        echo "${{ inputs.packages }}" > /tmp/packages.txt
-        cat /tmp/packages.txt
+        HASH=`echo "${{ inputs.packages }}" | md5sum | cut -d ' ' -f 1`
+        echo "packages-hash=$HASH" >> $GITHUB_OUTPUT
     - name: Load cache
       id: load-cache
       uses: actions/cache/restore@v3
       with:
         path: ~/texlive
-        key: texlive-${{ inputs.cache_version }}-${{ hashFiles('/tmp/packages.txt') }}-${{ steps.get-date.outputs.date }}
+        key: texlive-${{ inputs.cache_version }}-${{ hashFiles(inputs.package_file) }}-${{ steps.key-parts.outputs.packages-hash }}-${{ steps.key-parts.outputs.date }}
     - run: ${{ github.action_path }}/texlive.sh
       if: steps.load-cache.outputs.cache-hit != 'true'
       id: install

--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,7 @@ runs:
   steps:
     - name: Prepare cache key
       id: key-parts
+      shell: sh
       run: |
         echo "date=$(date -I)" >> $GITHUB_OUTPUT
         HASH=`echo "${{ inputs.packages }}" | md5sum | cut -d ' ' -f 1`

--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,7 @@ runs:
       id: get-date
       run: |
         echo "date=$(date -I)" >> $GITHUB_OUTPUT
-        echo "${{ github.event.inputs.packages }}" > /tmp/packages.txt
+        echo "${{ inputs.packages }}" > /tmp/packages.txt
     - name: Load cache
       id: load-cache
       uses: actions/cache/restore@v3

--- a/action.yml
+++ b/action.yml
@@ -24,17 +24,18 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - name: Get date
+    - name: Prepare cache key
       shell: sh
       id: get-date
       run: |
         echo "date=$(date -I)" >> $GITHUB_OUTPUT
+        echo "${{ github.event.inputs.packages }}" > /tmp/packages.txt
     - name: Load cache
       id: load-cache
       uses: actions/cache/restore@v3
       with:
         path: ~/texlive
-        key: texlive-${{ inputs.cache_version }}-${{ hashFiles(inputs.package_file) }}-${{ hashFiles(inputs.packages) }}-${{ steps.get-date.outputs.date }}
+        key: texlive-${{ inputs.cache_version }}-${{ hashFiles(inputs.package_file, '/tmp/packages.txt') }}-${{ steps.get-date.outputs.date }}
     - run: ${{ github.action_path }}/texlive.sh
       if: steps.load-cache.outputs.cache-hit != 'true'
       id: install

--- a/test.tex
+++ b/test.tex
@@ -1,0 +1,4 @@
+\documentclass{article}
+\begin{document}
+test
+\end{document}

--- a/texlive.sh
+++ b/texlive.sh
@@ -7,7 +7,6 @@
 
 # See if there is a cached version of TL available
 export PATH=$HOME/texlive/bin/x86_64-linux:$PATH
-echo "$HOME/texlive/bin/x86_64-linux" >> $GITHUB_PATH
 if ! command -v texlua > /dev/null; then
   # Obtain TeX Live
   wget "${TEXLIVE_REPOSITORY:-http://mirror.ctan.org/systems/texlive/tlnet}/install-tl-unx.tar.gz"


### PR DESCRIPTION
1. I had the issue that `l3build` was not found when the cache was restored (at https://github.com/koppor/tagpdf/pull/1). I think, it's about a missing `PATH` update. This PR fixes it.
2. The cache did not take into account the `packages` option. This PR fixes that, too.
3. This PR adds a GitHub workflow to check the action itself

I also removed `restore-keys`, which seems to be a left-over of development, when `${{ steps.get-date.outputs.date }}` was not present (which should never be the case now)

## Screenshot of l3build missing

![image](https://github.com/koppor/install-texlive/assets/1366654/bfe6e6cd-b78b-49c2-91de-c459f15381fa)
