### PR TITLE
Update action versions in code and README

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Run the action
       uses: ./
       with:
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Run the action
       uses: ./
       with:

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install TeX Live
-        uses: zauguin/install-texlive@v2
+        uses: zauguin/install-texlive@v3
         with:
           packages: >
             l3build latex latex-bin luatex latex-bin-dev
@@ -32,7 +32,7 @@ Instead of specifying the packages directly, you can pass a file containing the 
 
 ```yaml
       - name: Install TeX Live
-        uses: zauguin/install-texlive@v2
+        uses: zauguin/install-texlive@v3
         with:
            package_file: tl_packages
 ```


### PR DESCRIPTION
`actions/checkout` has released both [v4.0.0](https://github.com/actions/checkout/releases/tag/v4.0.0) and [v4.1.1](https://github.com/actions/checkout/releases/tag/v4.1.1) on 2023-10-17.