### PR TITLE
wget should be quiet

### DIFF
--- a/texlive.sh
+++ b/texlive.sh
@@ -9,7 +9,7 @@
 export PATH=$HOME/texlive/bin/x86_64-linux:$PATH
 if ! command -v texlua > /dev/null; then
   # Obtain TeX Live
-  wget "${TEXLIVE_REPOSITORY:-http://mirror.ctan.org/systems/texlive/tlnet}/install-tl-unx.tar.gz"
+  wget -q "${TEXLIVE_REPOSITORY:-http://mirror.ctan.org/systems/texlive/tlnet}/install-tl-unx.tar.gz"
   tar -xzf install-tl-unx.tar.gz
   cd install-tl-20*
 


### PR DESCRIPTION
When debugging a failing texlive installation, the issue is typically not in the wget of the installer. Thus, I propose to add `-q` to wget to reduce the noice.

![image](https://github.com/zauguin/install-texlive/assets/1366654/0a8083d8-3a87-41b2-83fa-b45ae09fd077)
