### PR TITLE
Add repeated (monthly) run

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,6 +1,13 @@
 name: Test Action
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  schedule:
+    - cron: '1 2 5 * *'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -32,3 +39,12 @@ jobs:
         cache_version: ${{ github.run_id }}_${{ github.run_attempt }}
         repository: https://127.0.0.42/not-a-texlive-mirror/
     - run: pdflatex test.tex
+
+  keepalive:
+    name: Keepalive
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: gautamkrishnar/keepalive-workflow@v2

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,8 +2,6 @@ name: Test Action
 
 on:
   push:
-    branches:
-      - main
   pull_request:
   schedule:
     - cron: '1 2 5 * *'


### PR DESCRIPTION
This modifies the CI check in following ways:

- only run a check once in a PR (and not triggered twice by a push and a pull request)
- monthly runs of the check (important when switching from TL 2023 to TL 2024 or to regular check for some interal TeXlive changes)
- add keep alive call to keep the "cronjob" active - even if there is no update in this repository