### PR TITLE
Remove unused "key" step

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -56,10 +56,6 @@ runs:
       with:
         path: ~/texlive
         key: ${{ steps.load-cache.outputs.cache-primary-key }}
-    - shell: sh
-      run: |
-        if ${{ steps.install.outcome == 'success' }} ; then echo "key=${{ steps.load-cache.outputs.cache-primary-key }}" ; else echo "key=${{ steps.load-cache.outputs.cache-matched-key }}" ; fi >> $GITHUB_OUTPUT
-      id: key
     - name: Set path
       if: runner.os == 'Linux'
       shell: sh


### PR DESCRIPTION
The manual determination of a key is not required any more. (Which I like: The cache is updated to the most recent version date after a successful install)