### PR TITLE
Add cache_hit output

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,13 @@ While the TeX Live pretest is running this can also be used to install the
 pretest. Just add the next (currently being tested) version number as
 `texlive_version`.
 
+## Outputs
+
+| Output      | Description                                                                                                                       |
+| ----------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `cache_key` | The key of the cache that was restored or saved.                                                                                  |
+| `cache_hit` | A boolean value indicating an exact match was found for the cache key, so TeX Live was restored from cache without reinstalling.   |
+
 ## FAQs
 
 > I miss the "basic" scheme of TeXLive. How can I install that?

--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,10 @@ inputs:
 outputs:
   cache_key:
     description: 'The updated or generated cache'
+  cache_hit:
+    description:
+      'A boolean value indicating an exact match was found for the cache key, so
+      TeX Live was restored from cache without reinstalling.'
 
 runs:
   using: node24

--- a/dist/index.js
+++ b/dist/index.js
@@ -103909,12 +103909,12 @@ async function findRepository(version) {
     }
     let candidateMirrors = Object.entries(mirrorList['North America'].USA).filter(([_, data]) => mirrorIsApplicable(data, version));
     if (candidateMirrors.length === 0) {
-        candidateMirrors = Object.entries(mirrorList['North America'])
-            .flatMap(([_, mirrors]) => Object.entries(mirrors))
+        candidateMirrors = Object.values(mirrorList['North America'])
+            .flatMap(mirrors => Object.entries(mirrors))
             .filter(([_, data]) => mirrorIsApplicable(data, version));
         if (candidateMirrors.length === 0) {
-            candidateMirrors = Object.entries(mirrorList)
-                .flatMap(([_, countryMirrors]) => Object.entries(countryMirrors).flatMap(([_, mirrors]) => Object.entries(mirrors)))
+            candidateMirrors = Object.values(mirrorList)
+                .flatMap(countryMirrors => Object.values(countryMirrors).flatMap(mirrors => Object.entries(mirrors)))
                 .filter(([_, data]) => mirrorIsApplicable(data, version));
             if (candidateMirrors.length === 0) {
                 throw new Error('No mirror available');

--- a/dist/index.js
+++ b/dist/index.js
@@ -104000,6 +104000,7 @@ async function run() {
         const home = external_node_os_namespaceObject.homedir();
         const tlPlatform = detectTlPlatform();
         addPath(`${home}/texlive/bin/${tlPlatform}`);
+        setOutput('cache_hit', false);
         let restoredCache;
         if (cacheKey) {
             info(`Trying to restore with key ${cacheKey.full}`);
@@ -104008,6 +104009,7 @@ async function run() {
             ]);
             if (restoredCache === cacheKey.full) {
                 setOutput('cache_key', restoredCache);
+                setOutput('cache_hit', true);
                 info(`Restored cache with key ${restoredCache}`);
                 return;
             }

--- a/src/main.ts
+++ b/src/main.ts
@@ -328,6 +328,8 @@ export async function run(): Promise<void> {
     const tlPlatform = detectTlPlatform()
     core.addPath(`${home}/texlive/bin/${tlPlatform}`)
 
+    core.setOutput('cache_hit', false)
+
     let restoredCache: string | undefined
     if (cacheKey) {
       core.info(`Trying to restore with key ${cacheKey.full}`)
@@ -336,6 +338,7 @@ export async function run(): Promise<void> {
       ])
       if (restoredCache === cacheKey.full) {
         core.setOutput('cache_key', restoredCache)
+        core.setOutput('cache_hit', true)
         core.info(`Restored cache with key ${restoredCache}`)
         return
       }

--- a/src/main.ts
+++ b/src/main.ts
@@ -162,16 +162,16 @@ async function findRepository(
     ([_, data]) => mirrorIsApplicable(data, version)
   ) as [string, AliveMirror][]
   if (candidateMirrors.length === 0) {
-    candidateMirrors = Object.entries(mirrorList['North America'])
-      .flatMap(([_, mirrors]) => Object.entries(mirrors))
+    candidateMirrors = Object.values(mirrorList['North America'])
+      .flatMap(mirrors => Object.entries(mirrors))
       .filter(([_, data]) => mirrorIsApplicable(data, version)) as [
       string,
       AliveMirror
     ][]
     if (candidateMirrors.length === 0) {
-      candidateMirrors = Object.entries(mirrorList)
-        .flatMap(([_, countryMirrors]) =>
-          Object.entries(countryMirrors).flatMap(([_, mirrors]) =>
+      candidateMirrors = Object.values(mirrorList)
+        .flatMap(countryMirrors =>
+          Object.values(countryMirrors).flatMap(mirrors =>
             Object.entries(mirrors)
           )
         )


### PR DESCRIPTION
Closes #59

Adds a `cache_hit` output to the action, mirroring the [`cache-hit` output of `actions/cache`](https://github.com/actions/cache?tab=readme-ov-file#outputs). This lets downstream workflow steps branch on whether TeX Live was restored from cache.

## Semantics

- `cache_hit` is `true` only when the cache is restored with an **exact** key match (TeX Live is used as-is, no reinstall/update).
- `cache_hit` is `false` otherwise — including partial/prefix restores, fresh installs, and when caching is disabled.

The output name uses an underscore (`cache_hit`) to stay consistent with the existing `cache_key` output.

## Changes

- `action.yml` — declare the `cache_hit` output.
- `src/main.ts` — default the output to `false`, set it to `true` on an exact cache restore.
- `README.md` — document the action's outputs.
- `dist/index.js` — rebundled via `npm run package`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)