### PR TITLE
Retry installation with a different mirror on checksum mismatch

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -103914,7 +103914,7 @@ async function findRepository(version) {
             .filter(([_, data]) => mirrorIsApplicable(data, version));
         if (candidateMirrors.length === 0) {
             candidateMirrors = Object.entries(mirrorList)
-                .flatMap(([_, countryMirrors]) => Object.entries(countryMirrors).flatMap(([_, mirrors]) => Object.entries(mirrors)))
+                .flatMap(([_continent, countryMirrors]) => Object.entries(countryMirrors).flatMap(([_country, mirrors]) => Object.entries(mirrors)))
                 .filter(([_, data]) => mirrorIsApplicable(data, version));
             if (candidateMirrors.length === 0) {
                 throw new Error('No mirror available');
@@ -103935,6 +103935,32 @@ function handleExecResult(description, status) {
     if (status === 0)
         return;
     throw new Error(`${description} failed with status code ${status}`);
+}
+// Number of times we attempt to install TeX Live before giving up. Mirrors are
+// occasionally out of sync and serve files with a mismatching checksum; in that
+// case retrying with a (hopefully different) randomly selected mirror usually
+// resolves the problem. See issue #56.
+const installAttempts = 3;
+async function installTexLiveWithRetry(initialInstall, initialRepository, requestedRepository, texlive_version, tlPlatform, packages) {
+    let repository = initialRepository;
+    for (let attempt = 1; attempt <= installAttempts; attempt++) {
+        try {
+            await installTexLive(initialInstall, repository, tlPlatform, packages);
+            return;
+        }
+        catch (error) {
+            if (attempt >= installAttempts) {
+                throw error;
+            }
+            warning(`TeX Live installation attempt ${attempt} of ${installAttempts} failed, retrying with a different mirror: ${error}`);
+            // If the user requested a specific repository we have to keep using it,
+            // otherwise pick a new random mirror in the hope of avoiding the one that
+            // served a file with a mismatching checksum.
+            if (requestedRepository === undefined) {
+                repository = (await findRepository(texlive_version))?.[0] ?? repository;
+            }
+        }
+    }
 }
 async function installTexLive(initialInstall, repository, tlPlatform, packages) {
     const tlmgr = tlPlatform === 'windows' ? 'tlmgr.bat' : 'tlmgr';
@@ -103982,7 +104008,8 @@ async function resolveRepository(texlive_version, requested_repository) {
 }
 async function run() {
     try {
-        const [repository, texlive_version, revision] = await resolveRepository(getOptionalNumberInput('texlive_version'), getOptionalInput('repository'));
+        const requestedRepository = getOptionalInput('repository');
+        const [repository, texlive_version, revision] = await resolveRepository(getOptionalNumberInput('texlive_version'), requestedRepository);
         const packageFile = getOptionalInput('package_file');
         const packagesInline = getOptionalInput('packages');
         const cacheVersion = getMandatoryInput('cache_version');
@@ -104014,7 +104041,7 @@ async function run() {
         }
         // Installing TeX Live gets another try block to handle acceptStale
         try {
-            await installTexLive(restoredCache === undefined, repository, tlPlatform, packages);
+            await installTexLiveWithRetry(restoredCache === undefined, repository, requestedRepository, texlive_version, tlPlatform, packages);
         }
         catch (error) {
             if (!acceptStale) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -170,8 +170,8 @@ async function findRepository(
     ][]
     if (candidateMirrors.length === 0) {
       candidateMirrors = Object.entries(mirrorList)
-        .flatMap(([_, countryMirrors]) =>
-          Object.entries(countryMirrors).flatMap(([_, mirrors]) =>
+        .flatMap(([_continent, countryMirrors]) =>
+          Object.entries(countryMirrors).flatMap(([_country, mirrors]) =>
             Object.entries(mirrors)
           )
         )
@@ -207,6 +207,42 @@ async function findRepository(
 function handleExecResult(description: string, status: number): void {
   if (status === 0) return
   throw new Error(`${description} failed with status code ${status}`)
+}
+
+// Number of times we attempt to install TeX Live before giving up. Mirrors are
+// occasionally out of sync and serve files with a mismatching checksum; in that
+// case retrying with a (hopefully different) randomly selected mirror usually
+// resolves the problem. See issue #56.
+const installAttempts = 3
+
+async function installTexLiveWithRetry(
+  initialInstall: boolean,
+  initialRepository: string | undefined,
+  requestedRepository: string | undefined,
+  texlive_version: number | undefined,
+  tlPlatform: TlPlatform,
+  packages: string[]
+): Promise<void> {
+  let repository = initialRepository
+  for (let attempt = 1; attempt <= installAttempts; attempt++) {
+    try {
+      await installTexLive(initialInstall, repository, tlPlatform, packages)
+      return
+    } catch (error) {
+      if (attempt >= installAttempts) {
+        throw error
+      }
+      core.warning(
+        `TeX Live installation attempt ${attempt} of ${installAttempts} failed, retrying with a different mirror: ${error}`
+      )
+      // If the user requested a specific repository we have to keep using it,
+      // otherwise pick a new random mirror in the hope of avoiding the one that
+      // served a file with a mismatching checksum.
+      if (requestedRepository === undefined) {
+        repository = (await findRepository(texlive_version))?.[0] ?? repository
+      }
+    }
+  }
 }
 
 async function installTexLive(
@@ -294,9 +330,10 @@ async function resolveRepository(
 
 export async function run(): Promise<void> {
   try {
+    const requestedRepository = getOptionalInput('repository')
     const [repository, texlive_version, revision] = await resolveRepository(
       getOptionalNumberInput('texlive_version'),
-      getOptionalInput('repository')
+      requestedRepository
     )
     const packageFile = getOptionalInput('package_file')
     const packagesInline = getOptionalInput('packages')
@@ -343,9 +380,11 @@ export async function run(): Promise<void> {
 
     // Installing TeX Live gets another try block to handle acceptStale
     try {
-      await installTexLive(
+      await installTexLiveWithRetry(
         restoredCache === undefined,
         repository,
+        requestedRepository,
+        texlive_version,
         tlPlatform,
         packages
       )


### PR DESCRIPTION
Fixes #56.

When a mirror is out of sync and serves a file with a mismatching checksum, the installation currently fails immediately. This implements the "relaxed" approach from #56: retry the installation instead of failing.

## Changes

- Add `installTexLiveWithRetry()` wrapping `installTexLive()` in a loop of up to **3 attempts**.
- On failure it logs a warning and, when the repository was auto-selected, re-runs `findRepository()` to pick a (hopefully different) random mirror for the next attempt. If the user pinned an explicit `repository`, that one is kept.
- The cache key is unaffected, since `findRepository()` always resolves to the same highest version/revision — only the mirror URL changes.
- The existing `accept-stale` cache-fallback still wraps the whole thing, so it only applies once all retries are exhausted.

## Verification

- `tsc --noEmit` typecheck passes
- `prettier --check` clean, ESLint clean on the new code
- `vitest` passes
- `dist/` rebuilt with `ncc` + `linefix` for the check-dist workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)