### PR TITLE
Fix no-shadow lint error

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -103914,7 +103914,7 @@ async function findRepository(version) {
             .filter(([_, data]) => mirrorIsApplicable(data, version));
         if (candidateMirrors.length === 0) {
             candidateMirrors = Object.entries(mirrorList)
-                .flatMap(([_, countryMirrors]) => Object.entries(countryMirrors).flatMap(([_, mirrors]) => Object.entries(mirrors)))
+                .flatMap(([_continent, countryMirrors]) => Object.entries(countryMirrors).flatMap(([_country, mirrors]) => Object.entries(mirrors)))
                 .filter(([_, data]) => mirrorIsApplicable(data, version));
             if (candidateMirrors.length === 0) {
                 throw new Error('No mirror available');

--- a/src/main.ts
+++ b/src/main.ts
@@ -170,8 +170,8 @@ async function findRepository(
     ][]
     if (candidateMirrors.length === 0) {
       candidateMirrors = Object.entries(mirrorList)
-        .flatMap(([_, countryMirrors]) =>
-          Object.entries(countryMirrors).flatMap(([_, mirrors]) =>
+        .flatMap(([_continent, countryMirrors]) =>
+          Object.entries(countryMirrors).flatMap(([_country, mirrors]) =>
             Object.entries(mirrors)
           )
         )


### PR DESCRIPTION
The worldwide-mirror fallback added in 6671d0c reuses the `_` placeholder for both the continent and the country key in its nested destructuring:

```js
Object.entries(mirrorList)
  .flatMap(([_, countryMirrors]) =>
    Object.entries(countryMirrors).flatMap(([_, mirrors]) =>
      Object.entries(mirrors)
    )
  )
```

The inner `_` shadows the outer one, which trips the `no-shadow` ESLint rule and currently breaks the **Lint Codebase** and **TypeScript Tests** jobs on `main`. This renames the unused keys to `_continent` / `_country`.

`dist/` is rebuilt accordingly (single-line change).

## Verification (node 24.11.0 per `.nvmrc`)

- `npm run lint` passes
- `npm run check` (tsc) passes
- `npm run ci-test` passes
- `npm run bundle` produces a clean `dist/` (only the renamed binding differs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)